### PR TITLE
Support for M1 Macs

### DIFF
--- a/lib/Sys/Info/Driver/OSX/Device/CPU.pm
+++ b/lib/Sys/Info/Driver/OSX/Device/CPU.pm
@@ -63,6 +63,9 @@ sub identify {
             $speed *= 1000;
         }
 
+        my $proc_num = $cpu->{number_processors};
+        $proc_num =~ s/proc (\d+).*/$1/; # M1 asymmetric cores
+
         push @{ $self->{META_DATA} }, {
             serial_number                => $cpu->{serial_number},
             architecture                 => $arch,
@@ -81,7 +84,7 @@ sub identify {
             L2_cache                     => { max_cache_size => $cache_size },
             flags                        => @flags ? [ sort @flags ] : undef,
             ( $byteorder ? (byteorder    => $byteorder):()),
-        } for 1..$cpu->{number_processors};
+        } for 1..$proc_num;
     }
 
     return $self->_serve_from_cache(wantarray);


### PR DESCRIPTION
The `system_profiler` call on the new ARM-based M1 Macs returns a `number_processors => 'proc 8:4:4'`, which is a total number of cores 8, with 4 performance, 4 low power. This is a simple change to pick the total number of cores. Processor speed and L2 Cache are not available with the called functions (they would differ between the 2 types of cores), so I guess it would be fine to return all cores as the same for now - unless someone can figure out how to get more detailed specs from the system.
I don't mind trying out things if the author doesn't have access to an M1.