### PR TITLE
Apple Silicon cpu_type->chip_type

### DIFF
--- a/lib/Sys/Info/Driver/OSX/Device/CPU.pm
+++ b/lib/Sys/Info/Driver/OSX/Device/CPU.pm
@@ -74,7 +74,7 @@ sub identify {
             address_width                => undef,
             bus_speed                    => $cpu->{bus_speed},
             speed                        => $speed,
-            name                         => $cpu->{cpu_type} || $name,
+            name                         => $cpu->{cpu_type} || $cpu->{chip_type} || $name,
             family                       => $mcpu->{family}{value},
             manufacturer                 => $mcpu->{vendor}{value},
             model                        => $mcpu->{model}{value},


### PR DESCRIPTION
For Apple Silicon macs, the system profiler returns a `chip_type` field instead of `cpu_type`.

No idea why Apple does silly changes like that, but this PR will make e.g. `$cpu->identify` to output `10 x Apple M1 Pro` instead of the current `10 x MacBookPro18,1` and still work with older macs.